### PR TITLE
Updated to support amethyst 0.15.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,18 +5,18 @@ authors = ["Jasper Meggitt <jasper.meggitt@gmail.com>"]
 edition = "2018"
 
 [features]
-default = ["amethyst/tiles"]
+default = ["amethyst/tiles", "amethyst/metal"]
 profiler = ["thread_profiler", "amethyst/profiler"]
 
 [dependencies]
 tiled = { git = "https://github.com/jmeggitt/rs-tiled.git" }
 sheep = "0.3.0"
-image = "0.22"
-amethyst = "0.13"
+image = "0.23.2"
+amethyst = "0.15.0"
 thread_profiler = {version = "0.3", optional = true }
 
 [dev-dependencies]
-log = { version = "0.4.6", features = ["serde"] }
+log = { version = "0.4.8", features = ["serde"] }
 
 [[example]]
 name = "concept"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Jasper Meggitt <jasper.meggitt@gmail.com>"]
 edition = "2018"
 
 [features]
-default = ["amethyst/tiles", "amethyst/metal"]
+default = ["amethyst/tiles"]
 profiler = ["thread_profiler", "amethyst/profiler"]
 
 [dependencies]

--- a/examples/concept/main.rs
+++ b/examples/concept/main.rs
@@ -103,7 +103,7 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path).with_clear([1.0; 4]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear([1.0; 4]),
                 )
                 .with_plugin(RenderTiles2D::<TileGid, FlatEncoder>::default()),
         )?;

--- a/src/format.rs
+++ b/src/format.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use amethyst::assets::{Format, FormatValue, Prefab, SingleFile, Source};
 use amethyst::Error;
-use image::{load_from_memory, DynamicImage, ImageError, RgbaImage};
+use image::{load_from_memory, DynamicImage, RgbaImage};
 use tiled::{parse, parse_tileset, TilesetRef};
 
 use crate::prefab::TileMapPrefab;

--- a/src/format.rs
+++ b/src/format.rs
@@ -90,7 +90,7 @@ impl Format<RgbaImage> for TiledFormat {
     fn import_simple(&self, bytes: Vec<u8>) -> Result<RgbaImage, Error> {
         match load_from_memory(&bytes[..])? {
             DynamicImage::ImageRgba8(v) => Ok(v),
-            _ => Err(ImageError::FormatError("Unable to read non rgba8 images".to_owned()).into()),
+            _ => Err(Error::from_string("Unable to read non rgba8 images".to_owned())),
         }
     }
 }


### PR DESCRIPTION
I've updated to amethyst 0.15. This was straightforward, with updates to Cargo.toml and also example/concept. 

An update for format was required as ImageError::FormatError no longer worked. This last change does mean we loose the ImageError and seems a pain.